### PR TITLE
Remove .clang-format

### DIFF
--- a/Optimized Voxel World/.clang-format
+++ b/Optimized Voxel World/.clang-format
@@ -1,3 +1,0 @@
-BasedOnStyle: Google
-IndentWidth: 4
-ColumnLimit: 120


### PR DESCRIPTION
Remove .clang-format to prevent Visual Studio from auto-formatting